### PR TITLE
Share session with subdomains

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_dostoevsky_session'
+Rails.application.config.session_store :cookie_store,
+                                       key: '_dostoevsky_session',
+                                       domain: :all,
+                                       tld_length: 2


### PR DESCRIPTION
Resolve https://github.com/installero/qkspace/issues/14

https://github.com/plataformatec/devise/wiki/How-To:-Use-subdomains

Работает, но конфликтует с сессиями, созданными до фикса. Необходимо сбросить все сессии всем пользователям после деплоя фикса и я не могу найти как это делается и делается ли это из кода или из командной строки. Нагуглил rake tmp:sessions:clear, но при локальной проверке это не сработало