### PR TITLE
Fix images count at og_images.rake

### DIFF
--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -22,7 +22,7 @@ namespace :og_images do
     end
 
     puts "Processing complete."
-    puts "Images count: 109"
+    puts "Images count: #{pages.size}"
     puts "Images generated: #{generated_count}" if generated_count.positive?
   end
 end


### PR DESCRIPTION
Фикс на некорректное отображение количества OpenGraph pictures в рейк таске